### PR TITLE
adding work-around for "unverified developer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This is very new, so it's not perfect, but it works(at least).
 - Use Penpot Desktop on your own server if you're self-hosting
 
 ## Downloads
-[Windows](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop%20Setup%200.0.3.exe) (Auto update included)
+[Windows](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop%20Setup%200.0.5.exe) (Auto update included)
 
-[macOS](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop-0.0.3.dmg) (No auto updates)
+[macOS](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop-0.0.5.dmg) (No auto updates)
 
 [Linux](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop-0.0.3.AppImage) (Auto update included)
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,24 @@ This is very new, so it's not perfect, but it works(at least).
 
 ## Features
 - Use Penpot Desktop on your own server if you're self-hosting
-- Dark mode on the Dashboard
-- Auto updates (macOS is currently not supported)
 
 ## Downloads
-[Windows](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop%20Setup%200.0.5.exe) (Auto update included)
+[Windows](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop%20Setup%200.0.3.exe) (Auto update included)
 
-[macOS](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop-0.0.5.dmg) (No auto updates)
+[macOS](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop-0.0.3.dmg) (No auto updates)
 
-[Linux](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop-0.0.5.AppImage) (Auto update included)
+[Linux](https://updates.korbsstudio.com/penpot-desktop/penpot-desktop-0.0.3.AppImage) (Auto update included)
+
+## First launch
+
+### MacOS
+(This is a temporary work-around until the issue is resolved.)
+When you launch the Penpot desktop app for the first time, macOS (from approx. version 11 and higher) may not allow it [to launch for security reasons](https://support.apple.com/en-gb/guide/mac-help/mh40616/12.0/mac/12.0).
+
+You may see an error message saying Penpot-Desktop "...cannot Be Opened Because the Developer Cannot Be Verified'. Until this has been resolved a work-around is:
+
+1. Navigate to the application in Finder
+2. Right-click the application icon and select "Open"
+3. Confirm in the dialog which will be shown
+
+The Penpot-Desktop app is now saved as an exception to your security settings, and you can open it in the future by double-clicking it just as you can any registered app.


### PR DESCRIPTION
At the moment when a MacOS user (on at least macOS version 11) tries to open the app, they are unable to successfully open it.

This edit adds a "first launch" section to the readme for users who do not know how to fix this.

The way to fix this would be to register the app with Apple. When this happens this error won't occur.

More info:
- [https://www.lifewire.com/fix-developer-cannot-be-verified-error-5183898](https://www.lifewire.com/fix-developer-cannot-be-verified-error-5183898)
- [https://support.apple.com/en-gb/guide/mac-help/mh40616/12.0/mac/12.0](https://support.apple.com/en-gb/guide/mac-help/mh40616/12.0/mac/12.0)